### PR TITLE
Add CJS wrapper and interop tests; update README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ Or read from a file:
 node dist/esm/bin.mjs --path ./fixtures/sample.txt
 ```
 
+## Library Usage
+
+ESM:
+
+```js
+import wordCounter, { countWordsForLocale, segmentTextByLocale } from "word-counter";
+```
+
+CJS:
+
+```js
+const wordCounter = require("word-counter");
+const { countWordsForLocale, segmentTextByLocale, showSingularOrPluralWord } =
+  wordCounter;
+```
+
 ### Display Modes
 
 Choose a breakdown style with `--mode` (or `-m`):
@@ -64,6 +80,16 @@ Examples:
 ```bash
 node dist/esm/bin.mjs --format raw "Hello world"
 node dist/esm/bin.mjs --format json --pretty "Hello world"
+```
+
+## Testing
+
+Run the build before tests so the CJS interop test can load the emitted
+`dist/cjs/index.cjs` bundle:
+
+```bash
+bun run build
+bun test
 ```
 
 ## Sample Inputs

--- a/docs/plans/jobs/2026-01-01-cjs-interop-test.md
+++ b/docs/plans/jobs/2026-01-01-cjs-interop-test.md
@@ -1,0 +1,23 @@
+---
+title: "Add CJS interop test and build notice"
+date: 2026-01-01
+status: completed
+agent: Codex
+---
+
+## Summary
+
+- Add a Bun test that verifies the CJS wrapper returns the default function
+  and exposes named exports.
+- Document that `bun run build` must run before tests because the CJS test
+  loads `dist/cjs/index.cjs`.
+
+## Rationale
+
+The CJS wrapper is emitted only during build, so tests need a build artifact
+available in `dist/` to validate interop behavior.
+
+## Changes
+
+- Added `test/cjs-interop.test.ts` to verify CJS wrapper behavior.
+- Documented build-before-test note in `README.md`.

--- a/docs/plans/jobs/2026-01-01-cjs-wrapper-exports.md
+++ b/docs/plans/jobs/2026-01-01-cjs-wrapper-exports.md
@@ -1,0 +1,24 @@
+---
+title: "CJS wrapper exports for mixed default/named entry"
+date: 2026-01-01
+status: completed
+agent: Codex
+---
+
+## Summary
+
+- Add a CJS wrapper entry so `require("word-counter")` returns the default export
+  while exposing named exports as properties.
+- Wire the CJS build and package exports to use the wrapper entry.
+- Document CJS usage and interop notes.
+
+## Rationale
+
+Tsdown warns about mixed default + named exports in the CJS bundle. A wrapper
+entry can provide cleaner CJS ergonomics while keeping ESM exports intact.
+
+## Changes
+
+- Added `src/index.cjs.ts` as the CJS wrapper entry.
+- Pointed the CJS build to the wrapper entry in `tsdown.config.ts`.
+- Documented ESM and CJS usage in `README.md`.

--- a/docs/plans/plan-2026-01-01-cjs-wrapper-exports.md
+++ b/docs/plans/plan-2026-01-01-cjs-wrapper-exports.md
@@ -1,0 +1,39 @@
+---
+title: "CJS wrapper exports for mixed default/named entry"
+date: 2026-01-01
+status: completed
+agent: Codex
+---
+
+# Goal
+
+Provide a CJS-friendly wrapper so `require("word-counter")` returns the default
+export directly while still exposing named exports, and avoid the mixed-exports
+warning in the CJS build.
+
+# Scope
+
+- Add a CJS wrapper entry that assigns `module.exports = wordCounter` and
+  attaches named exports as properties.
+- Update build config and package exports to point CJS to the wrapper.
+- Keep ESM entry as-is for default + named exports.
+- Document the CJS usage and any interop notes.
+
+# Non-Goals
+
+- Changing the public API shape for ESM consumers.
+- Removing default or named exports.
+
+# Plan
+
+1. Inspect current build outputs and entry wiring (`src/index.ts`, tsdown config,
+   `package.json` exports).
+2. Add a new CJS entry file and wire it into the build.
+3. Update `package.json` exports for CJS to use the wrapper.
+4. Adjust docs/README with CJS usage example.
+5. Run build/tests (if requested) and confirm no mixed-exports warning for CJS.
+
+# Risks
+
+- Incorrect wrapper wiring could break CJS consumers or types resolution.
+- CJS wrapper must stay in sync with named exports.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-counter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",
@@ -25,6 +25,7 @@
     "build": "tsdown",
     "type-check": "tsc -p tsconfig.json",
     "test": "bun test",
+    "test:ci": "bun run build && bun test",
     "cli": "node dist/esm/bin.mjs"
   },
   "devDependencies": {

--- a/src/index.cjs.ts
+++ b/src/index.cjs.ts
@@ -1,0 +1,12 @@
+import wordCounter, { countWordsForLocale, segmentTextByLocale } from "./wc";
+import { showSingularOrPluralWord } from "./utils";
+
+const cjsExports = Object.assign(wordCounter, {
+  default: wordCounter,
+  wordCounter,
+  countWordsForLocale,
+  segmentTextByLocale,
+  showSingularOrPluralWord,
+});
+
+export = cjsExports;

--- a/test/cjs-interop.test.ts
+++ b/test/cjs-interop.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const cjs = require("../dist/cjs/index.cjs");
+
+describe("CJS wrapper interop", () => {
+  test("require() returns default function with named properties", () => {
+    expect(typeof cjs).toBe("function");
+    expect(cjs.default).toBe(cjs);
+    expect(cjs.wordCounter).toBe(cjs);
+    expect(typeof cjs.countWordsForLocale).toBe("function");
+    expect(typeof cjs.segmentTextByLocale).toBe("function");
+    expect(typeof cjs.showSingularOrPluralWord).toBe("function");
+  });
+
+  test("default function works", () => {
+    const result = cjs("Hello world");
+    expect(result.total).toBe(2);
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -14,7 +14,7 @@ export default defineConfig([
     fixedExtension: true,
   },
   {
-    entry: { index: "src/index.ts" },
+    entry: { index: "src/index.cjs.ts" },
     format: ["cjs"],
     dts: false,
     outDir: "dist/cjs",


### PR DESCRIPTION
Introduce a CommonJS (CJS) wrapper to ensure compatibility with mixed default and named exports. Add tests to verify the CJS wrapper functionality and update documentation to reflect usage instructions. Adjust package configuration to support the new CJS entry point.