### PR TITLE
Add npm publish workflow and update version to 0.0.8-canary.0

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,0 +1,119 @@
+name: Publish to NPM Packages
+
+on:
+    push:
+        tags:
+            - "*"
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Tag to publish (e.g. v1.2.3)"
+                required: true
+                type: string
+
+permissions:
+    id-token: write # Required for OIDC authentication
+    contents: read
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+            - name: Resolve tag
+              id: tag
+              env:
+                  TAG_INPUT: ${{ inputs.tag }}
+              run: |
+                  if [ -n "$TAG_INPUT" ]; then
+                    echo "tag=$TAG_INPUT" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Ensure tag is on allowed branch
+              run: |
+                  git fetch origin main --depth=1
+                  git fetch origin "beta*" "alpha*" "canary*" "dev*" --depth=1 || true
+                  TAG_COMMIT=$(git rev-list -n 1 "${{ steps.tag.outputs.tag }}")
+                  if git merge-base --is-ancestor "$TAG_COMMIT" "origin/main"; then
+                    echo "Tag commit is on main."
+                    exit 0
+                  fi
+
+                  MATCHING_BRANCH=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin \
+                    | grep -Ei 'origin/.*(beta|alpha|canary|dev)' \
+                    | while read -r branch; do
+                        if git merge-base --is-ancestor "$TAG_COMMIT" "$branch"; then
+                          echo "$branch"
+                          break
+                        fi
+                      done)
+
+                  note() { echo "$1"; }
+                  if [ -n "$MATCHING_BRANCH" ]; then
+                    note "Tag commit is on allowed branch: $MATCHING_BRANCH"
+                  else
+                    note "Tag commit is not on main or an allowed branch (beta/alpha/canary/dev)." >&2
+                    exit 1
+                  fi
+
+            - name: Check pre-release status
+              id: prerelease
+              env:
+                  TAG_NAME: ${{ steps.tag.outputs.tag }}
+              run: |
+                  PRERELEASE_LABEL=""
+                  if [[ "$TAG_NAME" == *-alpha* ]]; then
+                    PRERELEASE_LABEL="alpha"
+                  elif [[ "$TAG_NAME" == *-beta* ]]; then
+                    PRERELEASE_LABEL="beta"
+                  elif [[ "$TAG_NAME" == *-rc* ]]; then
+                    PRERELEASE_LABEL="rc"
+                  elif [[ "$TAG_NAME" == *-canary* ]]; then
+                    PRERELEASE_LABEL="canary"
+                  fi
+
+                  if [[ -n "$PRERELEASE_LABEL" ]]; then
+                    echo "IS_PRERELEASE=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "IS_PRERELEASE=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+                  echo "PRERELEASE_LABEL=$PRERELEASE_LABEL" >> "$GITHUB_OUTPUT"
+
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Setup Node
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 20
+                  registry-url: https://registry.npmjs.org
+
+            - name: Update npm to latest # Ensuring NPM Trusted Publishing is Work
+              run: npm install -g npm@latest
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Build
+              run: bun run build
+
+            - name: Publish
+              run: |
+                  if [[ "${{ steps.prerelease.outputs.IS_PRERELEASE }}" == "true" ]]; then
+                    npm publish --registry https://registry.npmjs.org --access public --provenance --tag next
+                    PKG_NAME=$(node -p "require('./package.json').name")
+                    PKG_VERSION=$(node -p "require('./package.json').version")
+                    npm dist-tag add "$PKG_NAME@$PKG_VERSION" "${{ steps.prerelease.outputs.PRERELEASE_LABEL }}" --registry https://registry.npmjs.org
+                  else
+                    npm publish --registry https://registry.npmjs.org --access public --provenance
+                  fi

--- a/README.md
+++ b/README.md
@@ -219,4 +219,4 @@ Each run prints the total word count plus a per-locale breakdown, helping you un
 
 ## License
 
-This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License — see the [LICENSE](https://github.com/dev-pi2pie/word-counter/blob/main/LICENSE) file for details.

--- a/docs/plans/jobs/2026-01-16-revise-npm-publish-workflow.md
+++ b/docs/plans/jobs/2026-01-16-revise-npm-publish-workflow.md
@@ -1,0 +1,15 @@
+---
+title: "Revise npm publish workflow for trusted publishing"
+date: 2026-01-16
+status: completed
+agent: Codex
+---
+
+## Summary
+
+- Updated the npm publish workflow name and removed the package name override step.
+- Dropped the unused `packages: write` permission for the npm workflow.
+
+## Rationale
+
+- The workflow now reflects its actual target and avoids forcing the npm scope to match the GitHub owner.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-pi2pie/word-counter",
-  "version": "0.0.7",
+  "version": "0.0.8-canary.0",
   "keywords": [
     "cli",
     "intl-segmenter",


### PR DESCRIPTION
Introduce a new workflow for publishing to NPM, ensuring trusted publishing and proper handling of pre-release tags. Update the package version to 0.0.8-canary.0.