### PR TITLE
Add export summary tables to README and update job record

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,60 @@ The package exports can be used after installing from GitHub Packages or linking
 ### ESM
 
 ```js
-import wordCounter, { countWordsForLocale, segmentTextByLocale } from "@dev-pi2pie/word-counter";
+import wordCounter, {
+  countWordsForLocale,
+  countSections,
+  parseMarkdown,
+  segmentTextByLocale,
+  showSingularOrPluralWord,
+} from "@dev-pi2pie/word-counter";
 ```
 
 ### CJS
 
 ```js
 const wordCounter = require("@dev-pi2pie/word-counter");
-const { countWordsForLocale, segmentTextByLocale, showSingularOrPluralWord } = wordCounter;
+const {
+  countWordsForLocale,
+  countSections,
+  parseMarkdown,
+  segmentTextByLocale,
+  showSingularOrPluralWord,
+} = wordCounter;
 ```
+
+### Export Summary
+
+#### Core API
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `default` | function | `wordCounter(text, options?) -> WordCounterResult` |
+| `wordCounter` | function | Alias of the default export. |
+| `countWordsForLocale` | function | Low-level helper for per-locale counts. |
+| `segmentTextByLocale` | function | Low-level helper for locale-aware segmentation. |
+
+#### Markdown Helpers
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `parseMarkdown` | function | Parses Markdown and detects frontmatter. |
+| `countSections` | function | Counts words by frontmatter/content sections. |
+
+#### Utility Helpers
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `showSingularOrPluralWord` | function | Formats singular/plural words. |
+
+#### Types
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `WordCounterOptions` | type | Options for the `wordCounter` function. |
+| `WordCounterResult` | type | Returned by `wordCounter`. |
+| `WordCounterBreakdown` | type | Breakdown payload in `WordCounterResult`. |
+| `WordCounterMode` | type | `"chunk" \| "segments" \| "collector"`. |
 
 ### Display Modes
 

--- a/docs/plans/jobs/2026-01-16-update-package-usage.md
+++ b/docs/plans/jobs/2026-01-16-update-package-usage.md
@@ -1,0 +1,13 @@
+---
+title: "Update package usage docs"
+date: 2026-01-16
+status: completed
+agent: codex
+---
+
+## Summary
+- Updated README library usage examples to reflect current ESM/CJS exports.
+- Documented the export summary with tables for core API, helpers, and types.
+
+## Rationale
+- Ensure docs match the published entrypoints and exports surfaced from `src/index.ts` and `src/index.cjs.ts`.


### PR DESCRIPTION
### Motivation

- Make the package exports and key return types explicit and easier to discover for ESM/CJS consumers. 
- Replace a terse list with a clearer, structured summary so readers can quickly find core API, helper, and type exports.

### Description

- Replaced the previous export-summary list in `README.md` with sectioned tables for `Core API`, `Markdown Helpers`, `Utility Helpers`, and `Types` to document the public surface. 
- Added `countSections` and `parseMarkdown` to the ESM and CJS usage examples in `README.md`. 
- Documented the default export signature as `wordCounter(text, options?) -> WordCounterResult` and listed named exports such as `countWordsForLocale` and `segmentTextByLocale`, plus types `WordCounterOptions`, `WordCounterResult`, `WordCounterBreakdown`, and `WordCounterMode`. 
- Updated the job record at `docs/plans/jobs/2026-01-16-update-package-usage.md` to note the table-based export summary change.

### Testing

- Docs-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969c6e6fbd88321ade16eedf1509d00)