### PR TITLE
Increase git fetch depth to 100 in release and publish workflows

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -38,8 +38,13 @@ jobs:
 
             - name: Ensure tag is on allowed branch
               run: |
-                  git fetch origin main --depth=1
-                  git fetch origin "beta*" "alpha*" "canary*" "dev*" --depth=1 || true
+                  git fetch origin main --depth=100
+                  git fetch origin \
+                    "refs/heads/beta*:refs/remotes/origin/beta*" \
+                    "refs/heads/alpha*:refs/remotes/origin/alpha*" \
+                    "refs/heads/canary*:refs/remotes/origin/canary*" \
+                    "refs/heads/dev*:refs/remotes/origin/dev*" \
+                    --depth=100 || true
                   TAG_COMMIT=$(git rev-list -n 1 "${{ steps.tag.outputs.tag }}")
                   if git merge-base --is-ancestor "$TAG_COMMIT" "origin/main"; then
                     echo "Tag commit is on main."

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -38,8 +38,13 @@ jobs:
 
             - name: Ensure tag is on allowed branch
               run: |
-                  git fetch origin main --depth=1
-                  git fetch origin "beta*" "alpha*" "canary*" "dev*" --depth=1 || true
+                  git fetch origin main --depth=100
+                  git fetch origin \
+                    "refs/heads/beta*:refs/remotes/origin/beta*" \
+                    "refs/heads/alpha*:refs/remotes/origin/alpha*" \
+                    "refs/heads/canary*:refs/remotes/origin/canary*" \
+                    "refs/heads/dev*:refs/remotes/origin/dev*" \
+                    --depth=100 || true
                   TAG_COMMIT=$(git rev-list -n 1 "${{ steps.tag.outputs.tag }}")
                   if git merge-base --is-ancestor "$TAG_COMMIT" "origin/main"; then
                     echo "Tag commit is on main."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,13 @@ jobs:
 
             - name: Ensure tag is on allowed branch
               run: |
-                  git fetch origin main --depth=1
-                  git fetch origin "beta*" "alpha*" "canary*" "dev*" --depth=1 || true
+                  git fetch origin main --depth=100
+                  git fetch origin \
+                    "refs/heads/beta*:refs/remotes/origin/beta*" \
+                    "refs/heads/alpha*:refs/remotes/origin/alpha*" \
+                    "refs/heads/canary*:refs/remotes/origin/canary*" \
+                    "refs/heads/dev*:refs/remotes/origin/dev*" \
+                    --depth=100 || true
                   TAG_COMMIT=$(git rev-list -n 1 "${{ steps.tag.outputs.tag }}")
                   if git merge-base --is-ancestor "$TAG_COMMIT" "origin/main"; then
                     echo "Tag commit is on main."

--- a/docs/plans/jobs/2026-01-16-fix-fetch-globs.md
+++ b/docs/plans/jobs/2026-01-16-fix-fetch-globs.md
@@ -1,0 +1,14 @@
+---
+title: "Fix branch glob fetching in release workflows"
+date: 2026-01-16
+status: completed
+agent: codex
+---
+
+## Summary
+- updated workflow branch fetch patterns to use explicit refspecs so git fetch works with globbed branch names.
+- increased fetch depth to 100 to improve tag ancestry detection for non-tip commits.
+- keeps allowed-branch validation intact for main, beta*, alpha*, canary*, and dev*.
+
+## Why
+- git fetch does not accept bare glob patterns (e.g., "beta*") as valid refspecs, causing release workflows to fail before checking branch ancestry.


### PR DESCRIPTION
### Motivation
- Improve tag ancestry detection because the previous `--depth=1` shallow fetch can omit older commits so `git merge-base --is-ancestor` may incorrectly fail for tags that are not branch tips. 
- Preserve the existing allowed-branch validation (main and prerelease branches) while reducing false negatives when checking tag ancestry. 

### Description
- Increased fetch depth to `100` for `git fetch origin main` and the prerelease branch fetches in ` .github/workflows/publish-github-packages.yml`, ` .github/workflows/publish-npm-packages.yml`, and ` .github/workflows/release.yml` using `--depth=100` and left the existing `|| true` fallback for optional branch fetches. 
- Continued use of explicit refspecs for prerelease branches (`refs/heads/<pattern>:refs/remotes/origin/<pattern>`) so `git fetch` succeeds for globbed branch patterns. 
- Updated the job record at `docs/plans/jobs/2026-01-16-fix-fetch-globs.md` to note the deeper fetch depth and the rationale. 

### Testing
- No automated tests were run; this is a workflow-only change and requires a GitHub Actions run to validate the improved ancestry detection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d5637c0083219cd731400fd63402)