### PR TITLE
ci(release): use Node 24 for publish jobs and remove npm self-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,11 +294,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22.22.2
+          node-version: 24
           registry-url: https://registry.npmjs.org
-
-      - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Ensure tag matches package version
         working-directory: release-package
@@ -348,7 +345,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22.22.2
+          node-version: 24
           registry-url: https://npm.pkg.github.com
           scope: "@${{ github.repository_owner }}"
 

--- a/docs/plans/jobs/2026-03-26-investigate-npm-self-update-failure.md
+++ b/docs/plans/jobs/2026-03-26-investigate-npm-self-update-failure.md
@@ -1,0 +1,44 @@
+---
+title: "investigate npm self-update failure in release workflow"
+created-date: 2026-03-26
+status: completed
+agent: Codex
+---
+
+## Goal
+
+Identify why the release job failed at `Update npm for trusted publishing` and separate workflow-level causes from runner-level causes.
+
+## Key Findings
+
+- The failing step is the explicit self-update in `.github/workflows/release.yml`:
+
+  ```yaml
+  - name: Update npm for trusted publishing
+    run: npm install -g npm@latest
+  ```
+
+- The failure occurs before `npm publish`, inside the npm CLI bundled with the Node.js toolcache installation selected by `actions/setup-node`.
+- The user-provided log points at `/opt/hostedtoolcache/node/22.22.2/.../npm/...` and fails with `MODULE_NOT_FOUND` for npm's internal dependency `promise-retry`.
+- That means the npm executable already present on the runner was incomplete or corrupted for that Node.js installation, so the workflow failed while asking the bundled npm to upgrade itself.
+- This is not caused by the package artifact, package metadata, or npm authentication. The publish step is never reached.
+- Repository history shows the self-update step was carried into `.github/workflows/release.yml` by the release-workflow consolidation on 2026-03-24.
+- Repository documentation is inconsistent with the current workflow: `docs/plans/jobs/2026-03-13-publish-npm-trusted-publishing-alignment.md` says npm was pinned, but the corresponding workflow revision still used `npm install -g npm@latest`.
+- `actions/setup-node@v6` does not expose an `npm-version` input in its documented inputs, so replacing the current step with `npm-version: 10.9.2` under `setup-node` is not a supported fix.
+
+## Implications
+
+- The immediate trigger is runner/toolcache npm corruption or packaging breakage for the selected Node.js image.
+- The repo-side contributing factor is the self-update step, because it forces the workflow to invoke the broken bundled npm before publish.
+- The most reliable workflow fix is to stop self-updating npm in the publish job, or to install a specific npm version using a mechanism that does not depend on the already-broken npm executable.
+
+## Evidence
+
+- Current workflow: `.github/workflows/release.yml`
+- Self-update step introduced to consolidated release flow in commit `37084fe` (`ci(release): consolidate publish workflows into release`)
+- Node pin updated to `22.22.2` later in commit `821715e` (`ci(workflows): patch Node 22 CI/CD pins to 22.22.2`)
+- Current package metadata does not enable npm package-manager caching and does not define publish-time npm hooks that would explain this failure.
+
+## Recommended Next Step
+
+Remove the `Update npm for trusted publishing` step from the npm publish job first, then re-run the release. If a newer npm is still required afterward, add an explicit and supported installation path separately after confirming the runner image is healthy.

--- a/docs/plans/jobs/2026-03-26-release-publish-node24-bootstrap-fix.md
+++ b/docs/plans/jobs/2026-03-26-release-publish-node24-bootstrap-fix.md
@@ -1,0 +1,28 @@
+---
+title: "release publish node24 bootstrap fix"
+created-date: 2026-03-26
+status: completed
+agent: Codex
+---
+
+## Goal
+
+Patch the release workflow so npm publishing no longer depends on a broken self-update path from the Node 22 bundled npm on GitHub-hosted runners.
+
+## What Changed
+
+- Updated `.github/workflows/release.yml` so `publish_npm` uses Node.js `24` instead of `22.22.2`.
+- Removed the `Update npm for trusted publishing` step (`npm install -g npm@latest`) from `publish_npm`.
+- Updated `.github/workflows/release.yml` so `publish_github_packages` also uses Node.js `24` instead of `22.22.2`.
+- Kept the `prepare` job on Node.js `22.22.2` so the release build still runs on the repository's current 22.x baseline.
+
+## Why
+
+- The npm publish failure occurred before `npm publish`, inside the npm CLI bundled with the Node.js `22.22.2` runner toolcache installation.
+- npm trusted publishing requires a modern npm CLI, and Node.js `24` already provides a compatible npm line without needing a self-update bootstrap step.
+- Moving both publish jobs to Node.js `24` avoids the broken npm bootstrap path in both registries' publish flows while keeping the build baseline unchanged.
+
+## Validation
+
+- Parsed `.github/workflows/release.yml` successfully as YAML after the change.
+- Rechecked that `publish_npm` still retains `id-token: write` and `NODE_AUTH_TOKEN: ""` for OIDC trusted publishing.


### PR DESCRIPTION
Hot fix